### PR TITLE
Reduce disk space consumption

### DIFF
--- a/command/workspace_add.go
+++ b/command/workspace_add.go
@@ -53,10 +53,6 @@ func WorkspaceAdd(arg ...string) error {
 	for i, c := range configs {
 		name := names[i]
 		image := filepath.Join(path, name+".tar.gz")
-		err = Store(name, image)
-		if err != nil {
-			return err
-		}
 		delay := delays[i]
 		w.Add(name, image, int64(delay), c)
 	}

--- a/command/workspace_restore.go
+++ b/command/workspace_restore.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/toxyl/devbox/config"
@@ -48,6 +49,15 @@ func WorkspaceRestore(arg ...string) error {
 	}
 	w.Path = dstDir
 	w.Save(file)
+
+	// remove the image files to save diskspace
+	for _, c := range w.Devboxes {
+		err = os.Remove(c.Image)
+		if err != nil {
+			return err
+		}
+	}
+
 	log.Success("Restored workspace to %s", glog.File(dstDir))
 	return nil
 }

--- a/command/workspace_store.go
+++ b/command/workspace_store.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/toxyl/devbox/config"
@@ -38,7 +39,20 @@ func WorkspaceStore(arg ...string) error {
 			return err
 		}
 	}
-	tar.FromDir(path, tarfile)
+	err = tar.FromDir(path, tarfile)
+	if err != nil {
+		log.Error("Could not store workspace to %s: %s", glog.File(tarfile), glog.Error(err))
+		return nil
+	}
+
+	// remove the image files to save diskspace
+	for _, c := range w.Devboxes {
+		err = os.Remove(c.Image)
+		if err != nil {
+			return err
+		}
+	}
+
 	log.Success("Stored workspace to %s", glog.File(tarfile))
 	return nil
 }


### PR DESCRIPTION
- workspace-add doesn't make tarballs from devboxes anymore
- workspace-store temporarily creates a tarball from each devbox and removes it once the workspace tarball has been written
- workspace-restore extracts devbox tarballs from the workspace tarball, creates the devboxes from them and then removes the tarballs